### PR TITLE
Bugfix and Tests for Date/Time/Timestamp helpers

### DIFF
--- a/Solar/Filter/ValidateInt.php
+++ b/Solar/Filter/ValidateInt.php
@@ -2,7 +2,20 @@
 /**
  * 
  * Validates that a value represents an integer.
- * 
+ *
+ * Note: In PHP an integer is a signed whole number with values between
+ * -2147483648 an +2147483647 (usually, but this is platform dependent).
+ * If you want to store a number that doesn't fit into this limits you
+ * will run into issues with validateInt(). Take, for example, the number
+ * 3581297294. This is a valid MySQL INT UNSIGNED value but is not an
+ * integer in PHP and therefore validateInt() will return false. You have
+ * to consider this if you want to store numbers that don't fit in a PHP
+ * integer (MySQL: INT UNSIGNED and BIGINT, other databases have similar
+ * types).
+ *
+ * @link http://us.php.net/manual/en/language.types.integer.php Info about Integers in PHP
+ * @link http://dev.mysql.com/doc/refman/5.0/en/numeric-types.html Info about Numeric Types in MySQL
+ *
  * @category Solar
  * 
  * @package Solar_Filter

--- a/Solar/Http/Request/Adapter.php
+++ b/Solar/Http/Request/Adapter.php
@@ -620,6 +620,7 @@ abstract class Solar_Http_Request_Adapter extends Solar_Base {
     {
         $allowed = array(
             Solar_Http_Request::METHOD_GET,
+            Solar_Http_Request::METHOD_HEAD,
             Solar_Http_Request::METHOD_POST,
             Solar_Http_Request::METHOD_PUT,
             Solar_Http_Request::METHOD_DELETE,

--- a/Solar/Http/Request/Adapter.php
+++ b/Solar/Http/Request/Adapter.php
@@ -620,7 +620,6 @@ abstract class Solar_Http_Request_Adapter extends Solar_Base {
     {
         $allowed = array(
             Solar_Http_Request::METHOD_GET,
-            Solar_Http_Request::METHOD_HEAD,
             Solar_Http_Request::METHOD_POST,
             Solar_Http_Request::METHOD_PUT,
             Solar_Http_Request::METHOD_DELETE,

--- a/Solar/View/Helper/Date.php
+++ b/Solar/View/Helper/Date.php
@@ -39,12 +39,20 @@ class Solar_View_Helper_Date extends Solar_View_Helper_Timestamp
      * 
      * @param string $format An optional custom [[php::date() | ]]
      * formatting string; null by default.
-     * 
+     *
+     * @param string $tz_origin an optional time zone name for the origin
+     * timestamp. If $tz_origin or $tz_output are not set, the default values
+     * (from config) will be used. The system time zone is used, if there are
+     * no time zones configured.
+     *
+     * @param string $tz_output an optional time zone name, the output timestamp
+     * will be converted to this time zone
+     *
      * @return string The formatted date string.
      * 
      */
-    public function date($spec, $format = null)
+    public function date($spec, $format = null, $tz_origin = null, $tz_output = null)
     {
-        return $this->_process($spec, $format);
+        return $this->_process($spec, $format, $tz_origin, $tz_output);
     }
 }

--- a/Solar/View/Helper/Time.php
+++ b/Solar/View/Helper/Time.php
@@ -39,12 +39,20 @@ class Solar_View_Helper_Time extends Solar_View_Helper_Timestamp
      * 
      * @param string $format An optional custom [[php::date() | ]]
      * formatting string; null by default.
-     * 
+     *
+     * @param string $tz_origin an optional time zone name for the origin
+     * timestamp. If $tz_origin or $tz_output are not set, the default values
+     * (from config) will be used. The system time zone is used, if there are
+     * no time zones configured.
+     *
+     * @param string $tz_output an optional time zone name, the output timestamp
+     * will be converted to this time zone
+     *
      * @return string The formatted date string.
      * 
      */
-    public function time($spec, $format = null)
+    public function time($spec, $format = null, $tz_origin = null, $tz_output = null)
     {
-        return $this->_process($spec, $format);
+        return $this->_process($spec, $format, $tz_origin, $tz_output);
     }
 }

--- a/tests/Test/Solar/View/Helper/Timestamp.php
+++ b/tests/Test/Solar/View/Helper/Timestamp.php
@@ -2,7 +2,11 @@
 /**
  * 
  * Concrete class test.
- * 
+ *
+ * The timezone offset values were extracted from the TimeZone Converter website
+ *
+ * @link http://www.timezoneconverter.com/cgi-bin/tzc.tzc
+ *
  */
 class Test_Solar_View_Helper_Timestamp extends Test_Solar_View_Helper {
     
@@ -57,6 +61,281 @@ class Test_Solar_View_Helper_Timestamp extends Test_Solar_View_Helper {
         $string = 'Nov 7, 1970, 12:34:56 pm';
         $actual = $helper->timestamp($string);
         $expect = strtotime($string);
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     * tests correct handling of timezone offset between UTC and
+     * Pacific/Honolulu (-10 hours)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetUtcHonolulu()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'UTC',
+            'tz_output' => 'Pacific/Honolulu',
+        ));
+        $string = '2010-01-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2009-12-31 14:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     *  tests correct handling of timezone offset between UTC and
+     * Pacific/Fiji (+12 hours)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetUtcFiji()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'UTC',
+            'tz_output' => 'Pacific/Fiji',
+        ));
+        $string = '2010-01-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2010-01-01 13:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     *  tests correct handling of timezone offset between Honolulu and
+     * Fiji (+22 hours)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetHonoluluFiji()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'Pacific/Honolulu',
+            'tz_output' => 'Pacific/Fiji',
+        ));
+        $string = '2010-01-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2010-01-01 23:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     *  tests correct handling of timezone offset between UTC and
+     * Europe/Berlin (+1 hour when DST isn't active)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetUtcBerlin()
+    {
+        $helper = $this->_view->newHelper('timestamp',array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'UTC',
+            'tz_output' => 'Europe/Berlin',
+        ));
+        $string = '2010-01-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2010-01-01 01:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     *  tests correct handling of timezone offset between UTC and
+     * Europe/Berlin (+2 hours when DST is active)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetUtcBerlinDst()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'UTC',
+            'tz_output' => 'Europe/Berlin',
+        ));
+        $string = '2010-06-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2010-06-01 02:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     *  tests correct handling of timezone offset between Berlin and
+     * Los Angeles (-9 hours when DST is active in both zones)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetBerlinLosAngelesDst()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'Europe/Berlin',
+            'tz_output' => 'America/Los_Angeles',
+        ));
+        $string = '2010-06-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2010-05-31 15:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     *  tests correct handling of timezone offset between Los Angeles and
+     * Berlin (+9 hours when DST is active in both zones)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetLosAngelesBerlinDst()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'America/Los_Angeles',
+            'tz_output' => 'Europe/Berlin',
+        ));
+        $string = '2010-06-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2010-06-01 09:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     * tests correct handling of timezone offset between Berlin and
+     * Honolulu (-11 hours when DST is not active in Berlin)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetBerlinHonolulu()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'Europe/Berlin',
+            'tz_output' => 'Pacific/Honolulu',
+        ));
+        $string = '2010-01-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2009-12-31 13:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     * tests correct handling of timezone offset between Berlin and
+     * Honolulu (-12 hours when DST is active in Berlin)
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetBerlinHonoluluDst()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'Europe/Berlin',
+            'tz_output' => 'Pacific/Honolulu',
+        ));
+        $string = '2010-06-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2010-05-31 12:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     * tests correct handling of timezone offset for a system timezone
+     * different from UTC
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetSystemTimezoneBerlin()
+    {
+        ini_set('date.timezone', 'Europe/Berlin');
+
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'Europe/Berlin',
+            'tz_output' => 'America/New_York',
+        ));
+        $string = '2010-01-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2009-12-31 18:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     * tests correct handling of timezone offset for a system timezone
+     * different from UTC
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetSystemTimezoneBerlinDst()
+    {
+        ini_set('date.timezone', 'Europe/Berlin');
+
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+            'tz_origin' => 'America/Los_Angeles',
+            'tz_output' => 'Pacific/Honolulu',
+        ));
+        $string = '2010-06-01 00:00:00';
+        $actual = $helper->timestamp($string);
+        $expect = '2010-05-31 21:00:00'; // Hawaii doesn't observe DST
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     * tests correct handling of timezone offset for a system timezone
+     * different from UTC. Using method params for setting time zones instead
+     * of config values.
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetParamsBerlinHonolulu()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+        ));
+        $string = '2010-01-01 00:00:00';
+        $actual = $helper->timestamp($string, null, 'Europe/Berlin', 'Pacific/Honolulu');
+        $expect = '2009-12-31 13:00:00';
+        $this->assertEquals($actual, $expect);
+    }
+
+    /**
+     *
+     * tests correct handling of timezone offset for a system timezone
+     * different from UTC Using method params for setting time zones instead
+     * of config values.
+     *
+     * @return void
+     *
+     **/
+    public function testTimestamp_timezoneOffsetParamsBerlinHonoluluDst()
+    {
+        $helper = $this->_view->newHelper('timestamp', array(
+            'format'    => 'Y-m-d H:i:s',
+        ));
+        $string = '2010-06-01 00:00:00';
+        $actual = $helper->timestamp($string, null, 'Europe/Berlin', 'Pacific/Honolulu');
+        $expect = '2010-05-31 12:00:00';
         $this->assertEquals($actual, $expect);
     }
 }


### PR DESCRIPTION
The timezone calculation in Date/Time/Timezone produces wrong results as described in Ticket 287 (http://solarphp.com/trac/core/ticket/287).

Furthermore setting input and output timezones for the view helpers at runtime is complicated (only possible via Solar_Config::set()), so I added two optional timezone parameters for the helper methods.
