### PR TITLE
Fixed parsing of access files where fields are separated by only one tab...

### DIFF
--- a/Solar/Access/Adapter/File.php
+++ b/Solar/Access/Adapter/File.php
@@ -71,7 +71,7 @@ class Solar_Access_Adapter_File extends Solar_Access_Adapter
         
         // get the access source and split into lines
         $src = file_get_contents($this->_config['file']);
-        $src = preg_replace('/[ \t]{2,}/', ' ', trim($src));
+        $src = preg_replace('/[ \t]+/', ' ', trim($src));
         $lines = explode("\n", $src);
         
         foreach ($lines as $line) {


### PR DESCRIPTION
_Let's try do the pull request right the second time ;)_

As discovered on the mailing list, there's a bug in Solar's parser for access control files.

From the mailing list: 

> If you look at this line
> 
> `$src = preg_replace('/[ \t]{2,}/', ' ', trim($src));`
> 
> all occurrences of at least _two_ spaces or _two_ tabs are replaced 
> by _one_ space. Later the line will be split at this space character.
> 
> If there's is one tab that's not followed by a second tab it's not 
> replaced by a space and therefore the split fails.
